### PR TITLE
Fix retain cycle

### DIFF
--- a/Sources/CombineLongPolling/LongPollingPublisher.swift
+++ b/Sources/CombineLongPolling/LongPollingPublisher.swift
@@ -92,7 +92,8 @@ extension LongPollingPublisher {
         }
 
         private func startPolling() {
-            DispatchQueue.global(qos: .utility).async {
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                guard let self = self else { return }
                 while({
                     defer { self.lock.unlock() }
                     self.lock.lock()


### PR DESCRIPTION
STR:
- have an app with a few long polls
- put the app in background
- wait a minute (t > long poll timeout)
- resume the app

Result:
- 💣 memory allocation skyrockets