### PR TITLE
Ensure that calling cancel() deallocates the subscription

### DIFF
--- a/Sources/CombineLongPolling/LongPollingPublisher.swift
+++ b/Sources/CombineLongPolling/LongPollingPublisher.swift
@@ -76,6 +76,8 @@ extension LongPollingPublisher {
             lock.lock()
             finished = true
             lock.unlock()
+            // Make sure to not wait for the semaphore, otherwise the object won't get allocated
+            semaphore.signal()
 
             buffer?.complete(completion: .finished)
             currentRequest = nil


### PR DESCRIPTION
On cancelling the subscription the semaphore is in waiting state. Therefore deinit is not being called and in the worst case many threads are being created. This PR makes sure to wake up the thread, so that the resources can be freed. 